### PR TITLE
Fix Page Title

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -491,9 +491,6 @@ if( !function_exists( 'layers_site_title' ) ) {
 		if ( is_feed() )
 			return $title;
 
-		// Add the site name.
-		$title .= get_bloginfo( 'name' );
-
 		// Add the site description for the home/front page.
 		$site_description = get_bloginfo( 'description', 'display' );
 


### PR DESCRIPTION
Now returns the correct title.

example: `PageName | MyTitle` instead `PageName | MyTitleMyTitle`