### PR TITLE
Update for googleapi maps link

### DIFF
--- a/core/widgets/modules/contact.php
+++ b/core/widgets/modules/contact.php
@@ -156,7 +156,7 @@ if( !class_exists( 'Layers_Contact_Widget' ) ) {
 			</section>
 
 			<?php if ( !isset( $wp_customize ) ) {
-				wp_enqueue_script( LAYERS_THEME_SLUG . " -map-api","http://maps.googleapis.com/maps/api/js?sensor=false");
+				wp_enqueue_script( LAYERS_THEME_SLUG . " -map-api","//maps.googleapis.com/maps/api/js?sensor=false");
 				wp_enqueue_script( LAYERS_THEME_SLUG . "-map-trigger", get_template_directory_uri()."/core/widgets/js/maps.js", array( "jquery" ) );
 			}  // Enqueue the map js ?>
 		<?php }


### PR DESCRIPTION
If the site is served over HTTPS, it's possible that the maps API link will be blocked because of mixed protocol.  I changed this to '//' instead of 'http://' so that it will adapt to HTTPS.  There may be other links statically coded for http:// that also need to be updated.

(sorry about the triple commit, but i can't abide spelling errors and had already pushed it to github)