### PR TITLE
set slides to empty array when all slides are deleted to prevent notice

### DIFF
--- a/core/widgets/modules/slider.php
+++ b/core/widgets/modules/slider.php
@@ -285,6 +285,10 @@ if( !class_exists( 'Layers_Slider_Widget' ) ) {
 					}
 				} // foreach checkboxes
 			} // if checkboxes
+			
+			if ( !isset( $new_instance['slides'] ) ) {
+				$new_instance['slides'] = array();
+			}
 
 			return $new_instance;
 		}


### PR DESCRIPTION
Fixes PHP notice returned when rendering an empty slider after all slides are deleted.