### PR TITLE
Class initialization cleanup

### DIFF
--- a/core/customizer/defaults.php
+++ b/core/customizer/defaults.php
@@ -13,15 +13,15 @@ class Layers_Customizer_Defaults {
 		
 		/**
 		 *
-		 * @var string
+		 * @var string 
 		 */
-		public $prefix;
-		
-		/**
-		 *
-		 * @var Layers_Customizer_Config
-		 */
-		public $config;
+    public $prefix;
+
+   /**
+	  *
+	  * @var Layers_Customizer_Config
+	  */
+    public $config;
 		
 
     /**
@@ -29,9 +29,9 @@ class Layers_Customizer_Defaults {
     */
 
     public static function get_instance(){
-				if( ! isset( self::$instance ) ) {
-					self::$instance = new Layers_Customizer_Defaults();
-				}
+        if( ! isset( self::$instance ) ) {
+            self::$instance = new Layers_Customizer_Defaults();
+        }
         return self::$instance;
     }
 

--- a/core/customizer/defaults.php
+++ b/core/customizer/defaults.php
@@ -10,12 +10,28 @@
 class Layers_Customizer_Defaults {
 
     private static $instance;
+		
+		/**
+		 *
+		 * @var string
+		 */
+		public $prefix;
+		
+		/**
+		 *
+		 * @var Layers_Customizer_Config
+		 */
+		public $config;
+		
 
     /**
-    *  Initiator
+    *  Retrieves static/global instance
     */
 
-    public static function init(){
+    public static function get_instance(){
+				if( ! isset( self::$instance ) ) {
+					self::$instance = new Layers_Customizer_Defaults();
+				}
         return self::$instance;
     }
 
@@ -24,10 +40,14 @@ class Layers_Customizer_Defaults {
     */
 
     public function __construct() {
-
         // Setup prefix to use
         $this->prefix  = LAYERS_THEME_SLUG . '-';
-
+    }
+		
+    /**
+     * Initializes the instance by registering the controls of it's config
+     */
+    public function init() {
         // Grab the customizer config
         $this->config = new Layers_Customizer_Config();
         foreach( $this->config->controls() as $section_key => $controls ) {
@@ -40,9 +60,8 @@ class Layers_Customizer_Defaults {
                 // Register default
                 $this->register_control_defaults( $setting_key, $control_data[ 'type' ], ( isset( $control_data['default'] ) ? $control_data['default'] : NULL ) );
             }
-        }
-
-    }
+        }			
+		}
 
     /**
     * Register Control Defaults

--- a/core/customizer/init.php
+++ b/core/customizer/init.php
@@ -12,10 +12,13 @@ class Layers_Customizer {
 	private static $instance;
 
 	/**
-	*  Initiator
+	*  Retrieve static/global instance of the Layers Customizer
 	*/
 
-	public static function init(){
+	public static function get_instance(){
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new Layers_Customizer();
+		}
 		return self::$instance;
 	}
 
@@ -24,6 +27,13 @@ class Layers_Customizer {
 	*/
 
 	public function __construct() {
+	}
+	
+	/**
+	 * Initializes the instance
+	 * @global type $wp_customize
+	 */
+	public function init() {
 		global $wp_customize;
 
 		// Setup some folder variables

--- a/core/customizer/registration.php
+++ b/core/customizer/registration.php
@@ -21,7 +21,10 @@ class Layers_Customizer_Regsitrar {
 	*  Initiator
 	*/
 
-	public static function init(){
+	public static function get_instance(){
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new Layers_Customizer_Regsitrar();
+		}
 		return self::$instance;
 	}
 
@@ -40,7 +43,12 @@ class Layers_Customizer_Regsitrar {
 
 		// Grab the customizer config
 		$this->config = new Layers_Customizer_Config();
-
+	}
+	
+	/**
+	 * Register the panels and sections based on this instance's config
+	 */
+	public function init() {
 		// Start registration with the panels & sections
 		$this->register_panels( $this->config->panels() );
 		$this->register_sections ( $this->config->sections() );

--- a/core/helpers/api.php
+++ b/core/helpers/api.php
@@ -14,7 +14,10 @@ class Layers_API {
     *  Initiator
     */
 
-    public static function init(){
+    public static function get_instance(){
+				if ( ! isset( self::$instance ) ) {
+					self::$instance = new Layers_API();
+				}
         return self::$instance;
     }
 
@@ -53,14 +56,4 @@ class Layers_API {
 
         return apply_filters( 'layers_extension_list' , $extension_list );
     }
-}
-
-if( !function_exists( 'layers_api_init' ) ) {
-    // Instantiate API Calls
-    function layers_api_init() {
-        $layer_updater = new Layers_API();
-        $layer_updater->init();
-    } // layer_updater_init
-
-    add_action( "after_setup_theme", "layers_api_init", 100 );
 }

--- a/core/helpers/api.php
+++ b/core/helpers/api.php
@@ -15,9 +15,9 @@ class Layers_API {
     */
 
     public static function get_instance(){
-				if ( ! isset( self::$instance ) ) {
-					self::$instance = new Layers_API();
-				}
+        if ( ! isset( self::$instance ) ) {
+	          self::$instance = new Layers_API();
+        }
         return self::$instance;
     }
 

--- a/core/helpers/migrator.php
+++ b/core/helpers/migrator.php
@@ -15,7 +15,10 @@ class Layers_Widget_Migrator {
 	*  Initiator
 	*/
 
-	public static function init(){
+	public static function get_instance(){
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new Layers_Widget_Migrator();
+		}
 		return self::$instance;
 	}
 
@@ -24,6 +27,9 @@ class Layers_Widget_Migrator {
 	*/
 
 	public function __construct() {
+	}
+	
+	public function init() {
 
 		if( isset( $_GET[ 'layers-export' ] ) ) $this->create_export_file();
 

--- a/core/helpers/post-types.php
+++ b/core/helpers/post-types.php
@@ -17,7 +17,10 @@ class Layers_Post_Types {
 	*  Initiator
 	*/
 
-	public static function init(){
+	public static function get_instance(){
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new Layers_Post_Types();
+		}
 		return self::$instance;
 	}
 
@@ -26,6 +29,9 @@ class Layers_Post_Types {
 	*/
 
 	public function __construct() {
+	}
+	
+	public function init() {
 
 		foreach ( $this->get_post_types() as $post_type_key => $post_type_details ) {
 

--- a/core/meta/init.php
+++ b/core/meta/init.php
@@ -17,7 +17,10 @@ class Layers_Custom_Meta {
 	*  Initiator
 	*/
 
-	public static function init(){
+	public static function get_instance(){
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new Layers_Custom_Meta();
+		}
 		return self::$instance;
 	}
 
@@ -39,6 +42,10 @@ class Layers_Custom_Meta {
 
 		// Get post meta
 		$this->custom_meta = $meta_config->meta_data();
+		
+	}
+	
+	public function init() {
 
 		// Enqueue Styles
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) , 50 );


### PR DESCRIPTION
* Pushed the hook based initialization of some of the global classes to a separate ```init``` method to allow the classes to be testable in the future.  
* Renamed the static init method to get_instance.  Though the methods were unused, I left them there in case there were future plans to make the global instances accessible.