### PR TITLE
Changing the logic of the title and excerpt output

### DIFF
--- a/core/widgets/modules/contact.php
+++ b/core/widgets/modules/contact.php
@@ -107,7 +107,7 @@ if( !class_exists( 'Layers_Contact_Widget' ) ) {
 
 			// Set Display Variables
 			$show_address_or_contactform = ( ( '' != $widget['address_shown'] && isset( $widget['show_address'] ) ) || ( $this->check_and_return( $widget, 'contact_form' ) && $this->check_and_return( $widget, 'show_contact_form' ) ) ) ? TRUE : FALSE ;
-			$show_title_or_excerpt = ( '' != $widget['title'] && '' != $widget['excerpt'] ) ? TRUE : FALSE ;
+			$show_title_or_excerpt = ( '' != $widget['title'] . $widget['excerpt'] ) ? TRUE : FALSE ;
 
 			/**
 			* Generate the widget container class


### PR DESCRIPTION
Currently the logic outputs that if there is no title and no excerpt then the condition is true. 

This result in nothing showing if only one of the conditions are met. 

Changing this will result in the title or excerpt showing if only one holds content and not the other.