### PR TITLE
Added a filter for submenus under the layers admin menu.

### DIFF
--- a/core/options-panel/init.php
+++ b/core/options-panel/init.php
@@ -317,6 +317,25 @@ function layers_options_panel_menu(){
 		);
 	}
 
+	// Filter for extension submenus
+	$ext_menus = array();
+	$ext_menus = apply_filters( LAYERS_THEME_SLUG . '_ext_menus', $ext_menus );
+
+	if( is_array( $ext_menus ) ){
+		foreach ( $ext_menus as $ext_menu ){
+
+			add_submenu_page(
+				LAYERS_THEME_SLUG . '-dashboard',
+				esc_html( $ext_menu['name'] ),
+				esc_html( $ext_menu['label'] ),
+				'edit_theme_options',
+				LAYERS_THEME_SLUG . '-' . strtolower( str_replace( ' ', '-', $ext_menu['name'] ) ),
+				$ext_menu['callback']
+			);
+
+		}
+	}
+
 	// Customize
 	add_submenu_page(
 		LAYERS_THEME_SLUG . '-dashboard',


### PR DESCRIPTION
This means, extensions can use a short piece of code to easily add submenus under the Layers admin menu. Not sure if I positioned it correctly, or added too too few user options - definitely a start!

Regarding issue https://github.com/Obox/layerswp/issues/194#issuecomment-114411456