### PR TITLE
Lookup tags with get_tag_link(), instead of get_term_link() which can…

### DIFF
--- a/core/helpers/post.php
+++ b/core/helpers/post.php
@@ -72,7 +72,7 @@ if( !function_exists( 'layers_post_meta' ) ) {
 					if( !$the_tags ) continue;
 
 					foreach ( $the_tags as $tag ){
-						$tags[] = ' <a href="'.get_term_link( $tag ).'" title="' . esc_attr( sprintf( __( "View all posts tagged %s", LAYERS_THEME_SLUG ), $tag->name ) ) . '">'.$tag->name.'</a>';
+						$tags[] = ' <a href="'.get_tag_link( $tag ).'" title="' . esc_attr( sprintf( __( "View all posts tagged %s", LAYERS_THEME_SLUG ), $tag->name ) ) . '">'.$tag->name.'</a>';
 					}
 					$meta_to_display[] = '<span class="meta-item meta-tags"><i class="l-tags"></i> ' . implode( __( ', ' , 'layerswp' ), $tags ) . '</span>';
 					break;


### PR DESCRIPTION
… throw an error.

Hi guys I think this is a bugfix.

Using the old `get_category_link()` returned empty links.

Using the latest `get_term_link()` produces an error on my server:

    "PHP message: PHP Catchable fatal error:  Object of class WP_Error could not be converted to string in .../wp-content/themes/layerswp/core/helpers/post.php on line 75" while reading response header from upstream, ..."

But using `get_tag_link()` works as expected. 

However, I have tested only against 2.0.1 release so far.