### PR TITLE
Added dependency option for Layer fields. Only working operator are =…

### DIFF
--- a/assets/js/layers.framework.js
+++ b/assets/js/layers.framework.js
@@ -13,6 +13,7 @@
  * 5 - FitVids
  * 6 - Layers Custom Easing
  * 7 - Swiper Height Matching Functions
+ * 8 - Container padding on first widgets for header fixed - helper funcion.
  *
  * Author: Obox Themes
  * Author URI: http://www.oboxthemes.com/

--- a/core/assets/admin.js
+++ b/core/assets/admin.js
@@ -32,6 +32,7 @@
  * 19 - Reset to Default
  * 20 - History States
  * 21 - Linking from one section/panel to another.
+ * 22 - Dependency for fields
  *
  * Author: Obox Themes
  * Author URI: http://www.oboxthemes.com/
@@ -1068,5 +1069,65 @@ jQuery(function($) {
 
 		return false;
 	});
+
+	/**
+	 * 22 - Dependency for fields
+	 *
+	 * Added dependency for all fields to hide the fileds on dependancy
+	 */
+	check_dependencies_for_fields();
+
+	function check_dependencies_for_fields() {
+		//	Check all dependencies
+		$('*[data-layers-dependency]').each(function(index, el) {
+
+			//	Check self selector
+			var self  	= $( el );
+			var id 		= self.attr('id');
+			var dep 	= self.data('layers-dependency');
+			
+			//	Check is array
+			if ( $.isArray( dep ) ) {
+
+				//	Get target, operator & value of dependencies of layers fields
+				var target 	= $('#' + dep[0] );
+				var op 		= dep[1];
+				var value 	= dep[2];
+
+				//	1. Initially - Set dependency for fields on change
+				apply_dependencies(target, self, op, value);
+
+				//	Trigger on target change event
+				target.change(function(event) {
+
+					//	2. Set dependency for fields on change
+					apply_dependencies(target, self, op, value);
+
+				});
+			}
+		});
+	}
+
+	function apply_dependencies(target, self, op, value) {
+
+		//	Get current field value
+		var curr_val = target.val();
+
+		//	Swith statement for all operators
+		switch(op) {
+			case '==': 		if ( curr_val == value ) {
+								self.show();
+							} else {
+								self.hide();
+							}
+			break;
+			case '!=': 		if ( curr_val != value ) {
+								self.show();
+							} else {
+								self.hide();
+							}
+			break;
+		}
+	}
 
 });

--- a/core/helpers/forms.php
+++ b/core/helpers/forms.php
@@ -196,7 +196,7 @@ class Layers_Form_Elements {
 			* Select boxes
 			*/
 			case 'select' : ?>
-				<select size="1" <?php echo implode ( ' ' , $input_props ); ?> <?php if( isset( $input->multiple ) ) echo 'multiple="multiple"'; ?>>
+				<select size="1" data-layers-dependency="<?php echo esc_html( json_encode( $input->dependency ) ); ?>" <?php echo implode ( ' ' , $input_props ); ?> <?php if( isset( $input->multiple ) ) echo 'multiple="multiple"'; ?>>
 					<?php if( NULL != $input->placeholder ) { ?>
 						<option value=''><?php echo esc_html( $input->placeholder ); ?></option>
 					<?php } // if NULL != placeholder ?>

--- a/core/widgets/modules/content.php
+++ b/core/widgets/modules/content.php
@@ -388,14 +388,37 @@ if( !class_exists( 'Layers_Content_Widget' ) ) {
 					<p class="layers-form-item">
 						<?php echo $this->form_elements()->input(
 							array(
-								'type' => 'text',
-								'name' => $this->get_field_name( 'title' ) ,
-								'id' => $this->get_field_id( 'title' ) ,
-								'placeholder' => __( 'Enter title here' , 'layerswp' ),
-								'value' => ( isset( $widget['title'] ) ) ? $widget['title'] : NULL ,
-								'class' => 'layers-text layers-large'
+								'type' => 'select',
+								'label' => __( 'Option - 1' , 'layerswp' ),
+								'name' => 'Option 1',
+								'id' => 'option-1',
+								'value' => NULL,
+								'options' => array(
+									'1' => __( 'Option 1' , 'layerswp' ),
+									'2' => __( 'Option 2' , 'layerswp' ),
+									'3' => __( 'Option 3' , 'layerswp' ),
+								)
 							)
-						); ?>
+						);
+						?>
+					</p>
+					<p class="layers-form-item">
+						<?php echo $this->form_elements()->input(
+							array(
+								'type' => 'select',
+								'label' => __( 'Option - 2' , 'layerswp' ),
+								'name' => 'Option 2',
+								'id' => 'option-2',
+								'value' => NULL,
+								'options' => array(
+									'4' => __( 'Option 4' , 'layerswp' ),
+									'5' => __( 'Option 5' , 'layerswp' ),
+									'6' => __( 'Option 6' , 'layerswp' ),
+								),
+								'dependency' => array( 'option-1', '!=', '2'  ),
+							)
+						);
+						?>
 					</p>
 					<p class="layers-form-item">
 						<?php echo $this->form_elements()->input(


### PR DESCRIPTION
Added dependency option for Layer fields.
Only working operator are == and !=.
Tested on default content widget by adding two drop down fields. Just for testing.
Working perfectly.

Refer:
![Dependency Example](http://surror.com/wp-content/uploads/2015/11/Customize-Required-Dev-%E2%80%93-surror-com.png)