### PR TITLE
Bug Fix Issue #74

### DIFF
--- a/partials/header-centered.php
+++ b/partials/header-centered.php
@@ -13,7 +13,7 @@
 
 <div class="column inline-right-nav">
 	<?php do_action( 'layers_before_header_nav' ); ?>
-	<?php wp_nav_menu( array( 'theme_location' => LAYERS_THEME_SLUG . '-primary-right' ,'container' => 'nav', 'container_class' => 'nav nav-horizontal', 'fallback_cb' => create_function('', 'echo "&nbsp";') ) ); ?>
+	<?php wp_nav_menu( array( 'theme_location' => LAYERS_THEME_SLUG . '-primary-right' ,'container' => 'nav', 'container_class' => 'nav nav-horizontal', 'fallback_cb' => 'layers_menu_fallback' ) ); ?>
 	<?php get_template_part( 'partials/responsive' , 'nav-button' ); ?>
 	<?php do_action( 'layers_after_header_nav' ); ?>
 </div>

--- a/sidebar-off-canvas.php
+++ b/sidebar-off-canvas.php
@@ -5,7 +5,7 @@
     </a>
 
     <div class="row content nav-mobile">
-        <?php wp_nav_menu( array( 'theme_location' => LAYERS_THEME_SLUG . '-primary' ,'container' => 'nav', 'container_class' => 'nav nav-vertical', 'fallback_cb' => create_function('', 'echo "&nbsp";') ) ); ?>
+        <?php wp_nav_menu( array( 'theme_location' => LAYERS_THEME_SLUG . '-primary' ,'container' => 'nav', 'container_class' => 'nav nav-vertical', 'fallback_cb' => 'layers_menu_fallback' ) ); ?>
     </div>
     <?php dynamic_sidebar( LAYERS_THEME_SLUG . '-off-canvas-sidebar' ); ?>
 </section>


### PR DESCRIPTION
replaced `create_function('', 'echo "&nbsp";')` with `'layers_menu_fallback'` as the value of  `fallback_cb` parameter of `wp_nav_menu` on 2 coinsurances. 

PS: I am new on Git. So, Please Ignore last PR. That made by mistakes.