### PR TITLE
Bug Fix Issue  #298

### DIFF
--- a/core/widgets/modules/post.php
+++ b/core/widgets/modules/post.php
@@ -257,7 +257,7 @@ if( !class_exists( 'Layers_Post_Widget' ) ) {
 										echo layers_post_featured_media(
 											array(
 												'postid' => get_the_ID(),
-												'wrap_class' => 'thumbnail push-bottom span-5 column' .  ( ( isset( $column['design'][ 'imageratios' ] ) && 'image-round' == $column['design'][ 'imageratios' ] ) ? ' image-rounded' : '' ),
+												'wrap_class' => 'thumbnail push-bottom span-5 column' .  ( ( isset( $widget['design'][ 'imageratios' ] ) && 'image-round' == $widget['design'][ 'imageratios' ] ) ? ' image-rounded' : '' ),
 												'size' => $use_image_ratio
 											)
 										);
@@ -305,7 +305,7 @@ if( !class_exists( 'Layers_Post_Widget' ) ) {
 										echo layers_post_featured_media(
 											array(
 												'postid' => get_the_ID(),
-												'wrap_class' => 'thumbnail-media' .  ( ( isset( $column['design'][ 'imageratios' ] ) && 'image-round' == $column['design'][ 'imageratios' ] ) ? ' image-rounded' : '' ),
+												'wrap_class' => 'thumbnail-media' .  ( ( isset( $widget['design'][ 'imageratios' ] ) && 'image-round' == $widget['design'][ 'imageratios' ] ) ? ' image-rounded' : '' ),
 												'size' => $use_image_ratio,
 												'hide_href' => false
 											)


### PR DESCRIPTION
Please see th issue #298 Image Round not renders round image on frontend.

replaced `$column['design'][ 'imageratios' ]` with `$widget['design'][ 'imageratios' ]`

`$column` is null on `Post` widget  and after the above action. The featured image of post got round shape as it should have as per the setting on widget. Please see the image below for the result.
![3](https://cloud.githubusercontent.com/assets/5094765/11451703/bd281110-95f9-11e5-9a1d-28ee21c8571a.png)
