### PR TITLE
Close Mobile Sidebar when tapping out

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -663,6 +663,23 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 			display: block;
 			text-align: left;
 		}
+		/*-- For Bug: No sub menu displayed in widgets --*/
+		.sidebar .widget.widget_nav_menu .sub-menu {
+			background-color: transparent;
+			visibility: visible;
+			opacity: 1;
+			position: relative;
+			top: auto;
+			left: auto;
+			border: none;
+		}
+		.sidebar .widget.widget_nav_menu .sub-menu li a {
+			padding: 0;
+		}
+		.sidebar .widget.widget_nav_menu .sub-menu li a:hover {
+			background-color: transparent;
+			color: rgba(0, 0, 0, 1);
+		}
 
 
 	/*---------------------------*/

--- a/assets/js/layers.framework.js
+++ b/assets/js/layers.framework.js
@@ -50,6 +50,39 @@ jQuery(function($) {
 		return false;
 
 	});
+
+    // Remove toggle on click of area which is not affected by toggle
+    $(document).on( 'click' , function(e) {
+
+        $('[data-toggle^="#"]').each(function() {
+            var $that = $(this);
+
+            // Get the target with hash
+            var $target =  $that.data( 'toggle' );
+
+            // Get the target id without hash
+            var $targetId = $target.replace(/^#/,'');
+
+            // Get the toggle class
+            var toggleClass = $that.data( 'toggle-class' );
+
+            if (
+                // If click is not made on the element itself
+            e.target.id != $targetId &&
+            // And if click is not inside the element
+            !$( e.target ).parents($target).size() &&
+            // And the target element has the toggled class
+            $( $target ).hasClass(toggleClass)
+            ) {
+                // Try to close it
+                $( $target ).toggleClass(toggleClass);
+
+                // Even if a single element is closed then prevent the default
+                // click that was executed
+                e.preventDefault && e.preventDefault();
+            }
+        });
+    });
 	/**
 	* 3 - Sticky Header
 	*/

--- a/core/assets/admin.js
+++ b/core/assets/admin.js
@@ -111,10 +111,14 @@ jQuery(function($) {
 			// We set multiple to false so only get one image from the uploader
 			attachment = file_frame.state().get('selection').first().toJSON();
 
-			// Remove any old image
 			$container.find('img video').remove();
 
 			// Fade in Remove button
+            // Remove any old image
+
+			// Also trigger click event on image-remove to go by the flow of
+			// previously selected image removal
+            $container.find('.layers-image-remove').trigger('click');
 			$container.find('.layers-image-remove').fadeIn();
 
 			// Set attachment to the large/medium size if they're defined

--- a/core/customizer/init.php
+++ b/core/customizer/init.php
@@ -112,6 +112,7 @@ class Layers_Customizer {
 				'nonce' => wp_create_nonce( 'layers-customizer-actions' ),
 				'builder_page' => ( isset( $_GET[ 'layers-builder' ] ) ? TRUE : FALSE ),
 				'enable_deep_linking' => ( get_theme_mod( 'layers-dev-switch-customizer-state-record' ) ),
+                'confirm_delete_text' => __('Are you sure you want to delete this widget?', 'layerswp'),
 			)
 		);
 	}


### PR DESCRIPTION
Issue: _When opening the side-menu in mobile view, a visitor should be able to tap outside of the menu and it must close._

Solution: Reading document click and checking if a toggle-able element was toggled previously, then close the toggle and ignore the click.
Precautions: If the click is on the toggle-able element or inside it, then do not take any actions.