### PR TITLE
PHP 8 implode function fix

### DIFF
--- a/core/widgets/modules/base.php
+++ b/core/widgets/modules/base.php
@@ -826,7 +826,7 @@ if( !class_exists( 'Layers_Widget' ) ) {
 				$result
 			);
 
-			$atts = ( isset( $result[0] ) && is_array( $result[0] ) ) ? implode( $result[0], ' ' ) : '' ;
+			$atts = ( isset( $result[0] ) && is_array( $result[0] ) ) ? implode( ' ', $result[0] ) : '' ;
 
 			echo $atts;
 		}


### PR DESCRIPTION
On PHP 8 implode function first argument is separator and second is array, and it produces fatal error if params are swapped, fixed one occurrence on line 829.